### PR TITLE
Add Badges, Fix Random Build Failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # go-libp2p-pubsub-grpc (pubsubgrpc)
 
+[![GoDoc](https://godoc.org/github.com/RTradeLtd/go-libp2p-pubsub-grpc?status.svg)](https://godoc.org/github.com/RTradeLtd/go-libp2p-pubsub-grpc) [![codecov](https://codecov.io/gh/RTradeLtd/go-libp2p-pubsub-grpc/branch/master/graph/badge.svg)](https://codecov.io/gh/RTradeLtd/go-libp2p-pubsub-grpc) [![Build Status](https://travis-ci.com/RTradeLtd/go-libp2p-pubsub-grpc.svg?branch=master)](https://travis-ci.com/RTradeLtd/go-libp2p-pubsub-grpc)
+
+
 `pubsubgrpc` provides a LibP2P PubSub framework that can be used as a stand-alone gRPC pubsub server and API, or as a module/component of existing gRPC servers to provide LibP2P PubSub functionality. It uses `proto3` and borrows some ideas from [libp2p/go-libp2p-daemon](https://github.com/libp2p/go-libp2p-daemon/blob/master/pb/p2pd.proto) and [libp2p/go-libp2p-pubsub](https://github.com/libp2p/go-libp2p-pubsub/tree/master/pb).
 
 # usage

--- a/pubsubgrpc_test.go
+++ b/pubsubgrpc_test.go
@@ -49,7 +49,8 @@ func TestPubSubService(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-
+	// wait for the gRPC server to spin up
+	time.Sleep(time.Second * 5)
 	client, err := pubsubgrpc.NewClient("", "", serverAddr)
 	if err != nil {
 		cancel()


### PR DESCRIPTION
Fixes a random build failure due to the off-chance that the client init, and first call has a chance to complete before the gRPC Server is fully constructed. This would only happen during tests